### PR TITLE
Added option to toggle feast dancers.

### DIFF
--- a/source/module_dialogs.py
+++ b/source/module_dialogs.py
@@ -34625,6 +34625,7 @@ I suppose there are plenty of bounty hunters around to get the job done . . .", 
 	[
 	(try_begin),
 		(ge, "$g_sexual_content", 1),
+    (eq, "$g_feast_dancers", 1),
 		(try_begin),
 				(eq, "$tep_entertainer1", "$g_talk_troop"),
 				(assign, ":tribute_entertainer", 1),

--- a/source/module_mission_templates.py
+++ b/source/module_mission_templates.py
@@ -5106,6 +5106,7 @@ mission_templates = [
         (call_script, "script_init_town_agent", ":agent_no"),
 		(try_begin),
 			(ge, "$g_sexual_content", 1),
+      (eq, "$g_feast_dancers", 1),
 			(eq, "$talk_context", tc_court_talk),
 			(agent_get_troop_id, ":troop_id", ":agent_no"),
 			(neg|eq, trp_player, ":troop_id"),

--- a/source/module_scripts.py
+++ b/source/module_scripts.py
@@ -117,6 +117,7 @@ scripts = [
       (assign, "$g_dark_hunters_enabled", 0),
       (assign, "$g_realistic_wounding", 0),
       (assign, "$g_polygamy", 0),
+    (assign, "$g_feast_dancers", 1),
 	  (assign, "$g_enable_shield_bash", 2),
 	  (assign, "$f_con", 0),
 	  (assign, "$f_player_prost", 0),

--- a/source/xgm_mod_options.py
+++ b/source/xgm_mod_options.py
@@ -97,6 +97,18 @@ mod_options = [
         ],
     ),
 
+    ( "camp_no_dancers", xgm_ov_checkbox ,  [],
+        "Feast Dancers:", 0,
+        "Toggles dancers during feasts.", 0,
+        [  # initialization block (set value in reg1)
+            (assign, reg1, "$g_feast_dancers"),
+        ],
+        [  # update block (value is in reg1)
+            (assign, "$g_feast_dancers", reg1),
+        ],
+    ),
+
+
     ("camp_dark_hunters", xgm_ov_checkbox, [], "Black Khergits and Dark Hunters:", 0,
      "Settings for Dark Hunters and Black Khergits.", 0,
   [


### PR DESCRIPTION
The camp menu now has a separate option for toggling feast dancers. Note that even if the option is enabled, adult content must still be enabled for dancers to appear. This just adds a way for dancers to be disabled when adult content is on.

Resolves #68